### PR TITLE
remove load_example, fix break nvim startup

### DIFF
--- a/lua/compiler-explorer/init.lua
+++ b/lua/compiler-explorer/init.lua
@@ -319,5 +319,4 @@ M.load_example = async.void(function()
   vim.filetype.match(bufname, 0)
 end)
 
-M.load_example()
 return M


### PR DESCRIPTION
After setup this plugin, when entering vim, will automatically execute load_example, this is unexpected behavier.

<img width="657" alt="image" src="https://user-images.githubusercontent.com/8556349/192124207-a3585862-0765-4f1d-838e-38c693ba5e11.png">
