### PR TITLE
Fix compile_live when no flags are specified & add option to specify default flags"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ require("compiler-explorer").setup({
   split = "split", -- How to split the window after the second compile (split/vsplit).
   spinner_frames = { "⣼", "⣹", "⢻", "⠿", "⡟", "⣏", "⣧", "⣶" }, -- Compiling... spinner settings.
   spinner_interval = 100,
+  compiler_flags = "", -- Default flags passed to the compiler.
 })
 ```
 

--- a/lua/compiler-explorer/config.lua
+++ b/lua/compiler-explorer/config.lua
@@ -17,6 +17,7 @@ M.defaults = {
   split = "split", -- How to split the window after the second compile (split/vsplit).
   spinner_frames = { "⣼", "⣹", "⢻", "⠿", "⡟", "⣏", "⣧", "⣶" },
   spinner_interval = 100,
+  compiler_flags = "",
 }
 
 M._config = M.defaults

--- a/lua/compiler-explorer/init.lua
+++ b/lua/compiler-explorer/init.lua
@@ -83,7 +83,7 @@ M.compile = async.void(function(opts)
     })
 
     -- Choose compiler options
-    args.flags = vim_input()({ prompt = "Select compiler options> " })
+    args.flags = vim_input()({ prompt = "Select compiler options> ", default = conf.compiler_flags })
     args.compiler = compiler.id
   end
 

--- a/lua/compiler-explorer/init.lua
+++ b/lua/compiler-explorer/init.lua
@@ -143,7 +143,7 @@ M.compile_live = async.void(function(opts)
       M.compile({
         line1 = 1,
         line2 = fn.line("$"),
-        fargs = { "compiler=" .. compiler, "flags=" .. flags },
+        fargs = { "compiler=" .. compiler, flags and "flags=" .. flags },
       })
     end,
   })


### PR DESCRIPTION
I'm getting the following error when using the compile_live without specifying any flag, so this PR fixes it.

```
Error detected while processing BufWritePost Autocommands for "<buffer=1>":
Error executing lua callback: ...rt/compiler-explorer.nvim/lua/compiler-explorer/init.lua:146: attempt to concatenate upvalue 'flags' (a nil value)
stack traceback:
        ...rt/compiler-explorer.nvim/lua/compiler-explorer/init.lua:146: in function <...rt/compiler-explorer.nvim/lua/compiler-explorer/init.lua:142>
```

Another thing it does is adding an option to specify default compiler flags, I use a few flags by default and it would be nice to have them show up by default rather than typing them continuously, let me know if you want me to revert it if you don't like it
