### PR TITLE
fix: return early from compile if *not* args.flags

### DIFF
--- a/lua/compiler-explorer/init.lua
+++ b/lua/compiler-explorer/init.lua
@@ -93,7 +93,7 @@ M.compile = async.void(function(opts)
 
     -- Choose compiler options
     args.flags = vim_input({ prompt = "Select compiler options> ", default = conf.compiler_flags })
-    if args.flags then
+    if not args.flags then
       return
     end
     args.compiler = compiler.id


### PR DESCRIPTION
Bug introduced in https://github.com/krady21/compiler-explorer.nvim/commit/761db3a6f7398ebd472b220b5f4b2937bd0e1c82
Previously, [compile](https://github.com/krady21/compiler-explorer.nvim/blob/master/lua/compiler-explorer/init.lua#L22) would continue execution _only if_ the user exited/cancelled the compiler options prompt (i.e., *only if* [get_input](https://github.com/krady21/compiler-explorer.nvim/blob/master/lua/compiler-explorer/init.lua#L14) returned `nil`).