### PR TITLE
Fix for #21: Compilation flags do not work

### DIFF
--- a/doc/compiler-explorer.txt
+++ b/doc/compiler-explorer.txt
@@ -29,7 +29,7 @@ COMMANDS                                          *compiler-explorer-commands*
                           prompted to select it interactively using *vim.ui.select*.
 
                         • flags={compiler-flags} Compiler flags
-                          comma•separated.
+                          space•separated.
 
                         • inferLang={true/false} If true, infer the language
                           based on file extension, otherwise prompt the user

--- a/lua/compiler-explorer/rest.lua
+++ b/lua/compiler-explorer/rest.lua
@@ -124,7 +124,7 @@ local function body_from_args(args)
 
     -- Allow passing flags more than once.
     if key == "flags" then
-      body.options.userArguments = body.options.userArguments .. value
+      body.options.userArguments = body.options.userArguments .. " " .. value
     end
   end
   return body


### PR DESCRIPTION
Updates help doc to say that flags need to space seperated and added space when concatenating flags.