### PR TITLE
fix(init): Avoid crash beacuse of a nil value

### DIFF
--- a/lua/compiler-explorer/init.lua
+++ b/lua/compiler-explorer/init.lua
@@ -117,7 +117,7 @@ M.compile = ce.async.void(function(opts, live)
           line1 = 1,
           line2 = fn.line("$"),
           fargs = {
-            "compiler=" .. args.compiler.id,
+            "compiler=" .. (args.compiler.id or args.compiler),
             "flags=" .. (args.flags or ""),
           },
         }, false)


### PR DESCRIPTION
When compiling in live mode, if the compiler to use is specified as an argument `CECompileLive compiler=g101`, a 'nil value concatenation' error is thrown.